### PR TITLE
Fix scrolling to top when all items on screen are collapsed

### DIFF
--- a/stickyheaders/src/main/java/org/zakariya/stickyheaders/StickyHeaderLayoutManager.java
+++ b/stickyheaders/src/main/java/org/zakariya/stickyheaders/StickyHeaderLayoutManager.java
@@ -190,8 +190,8 @@ public class StickyHeaderLayoutManager extends RecyclerView.LayoutManager {
 		int totalVendedHeight = 0;
 
 		// If we emptied the view with a notify, we may overshoot and fail to draw
-		if (firstViewAdapterPosition > state.getItemCount()) {
-			firstViewAdapterPosition = 0;
+		if (firstViewAdapterPosition >= state.getItemCount()) {
+			firstViewAdapterPosition = state.getItemCount() - 1;
 		}
 
 		// walk through adapter starting at firstViewAdapterPosition stacking each vended item


### PR DESCRIPTION
Previously if all items on screen were cleared with a collapse event, the adapter would return to the top