### PR TITLE
Fixes issue where RecyclerView is throwing an IllegalArgumentExceptio…

### DIFF
--- a/stickyheaders/src/main/java/org/zakariya/stickyheaders/SectioningAdapter.java
+++ b/stickyheaders/src/main/java/org/zakariya/stickyheaders/SectioningAdapter.java
@@ -267,8 +267,6 @@ public class SectioningAdapter extends RecyclerView.Adapter<SectioningAdapter.Vi
 	 */
 	public GhostHeaderViewHolder onCreateGhostHeaderViewHolder(ViewGroup parent) {
 		View ghostView = new View(parent.getContext());
-		ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-		parent.addView(ghostView, layoutParams);
 		return new GhostHeaderViewHolder(ghostView);
 	}
 


### PR DESCRIPTION
Fixes issue where RecyclerView is throwing an IllegalArgumentException when trying to recycler view holders. Because the library was adding a view to the parent ViewGroup in onCreateGhostHeaderViewHolder, when the RecyclerView tried to recycle the ViewHolder it checked if the parent ViewGroup is not null. If the ViewGroup is not null, the RecyclerView will throw an IllegalArgumentException.