### PR TITLE
Fix NPE in scrollVerticallyBy when top/bottom-most view not found

### DIFF
--- a/stickyheaders/src/main/java/org/zakariya/stickyheaders/StickyHeaderLayoutManager.java
+++ b/stickyheaders/src/main/java/org/zakariya/stickyheaders/StickyHeaderLayoutManager.java
@@ -303,6 +303,10 @@ public class StickyHeaderLayoutManager extends RecyclerView.LayoutManager {
 			// content moving downwards, so we're panning to top of list
 
 			View topView = getTopmostChildView();
+			if (topView == null) {
+				return 0;
+			}
+
 			while (scrolled > dy) {
 
 				// get the topmost view
@@ -366,6 +370,9 @@ public class StickyHeaderLayoutManager extends RecyclerView.LayoutManager {
 
 			int parentHeight = getHeight();
 			View bottomView = getBottommostChildView();
+			if (bottomView == null) {
+				return 0;
+			}
 
 			while (scrolled < dy) {
 				int hangingBottom = Math.max(getDecoratedBottom(bottomView) - parentHeight, 0);


### PR DESCRIPTION
Fixed NPE in `scrollVerticallyBy`. 

This NPE might happen after dataset change when use dynamic item type with inner RecyclerView. 
`scrollVerticallyBy` might run many times during the layout. In middle state of them, there might be only 1 item with type TYPE_HEADER that exist in child views, and  thus `getTopmostChildView`/`getBottommostChildView` will return Null. 
And then the `getDecoratedTop`/`getDecoratedBottom` will trigger the NPE.

Fixed by: simply add Null check and return 0. In the later layout pass, child view will be added and `scrollVerticallyBy` will work normally.