### PR TITLE
fixed issue where layout doesn't change when item count goes down to 0

### DIFF
--- a/stickyheaders/src/main/java/org/zakariya/stickyheaders/StickyHeaderLayoutManager.java
+++ b/stickyheaders/src/main/java/org/zakariya/stickyheaders/StickyHeaderLayoutManager.java
@@ -161,7 +161,12 @@ public class StickyHeaderLayoutManager extends RecyclerView.LayoutManager {
 	@Override
 	public void onLayoutChildren(RecyclerView.Recycler recycler, RecyclerView.State state) {
 
-		if (adapter == null || adapter.getItemCount() == 0) {
+		if (adapter == null) {
+			return;
+		}
+
+		if (adapter.getItemCount() == 0) {
+			removeAndRecycleAllViews(recycler);
 			return;
 		}
 


### PR DESCRIPTION
in case anyone uses some sort of filters there is a possibility that items count could go down to 0 which was not handled by the layout manager where it simply returns when ``state.itemCount == 0`` which cause the layout to stay the same as last rendering cycle while it should remove and recycle all views in case there were any

Signed-off-by: Amgad Serry <amgad.serry@hotmail.com>